### PR TITLE
Add a build system based on docker and docker-compose

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+src/*
+bower_components/*
+node_modules/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:4
+
+RUN mkdir -p /code
+WORKDIR /code
+
+COPY . /code
+RUN npm install bower -g  --loglevel=warn
+RUN npm install  --loglevel=warn
+RUN bower install  --loglevel=warn --allow-root
+
+CMD [ "npm", "start" ]

--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 # Online chart for [OpenSeaMap](http://openseamap.org)
+
 [![Build Status](https://travis-ci.org/aAXEe/online_chart_ol3.svg?branch=master)](https://travis-ci.org/aAXEe/online_chart_ol3)
+[![Dependency Status](https://david-dm.org/aAXEe/online_chart_ol3.svg)](https://david-dm.org/aAXEe/online_chart_ol3)
+[![devDependency Status](https://david-dm.org/aAXEe/online_chart_ol3/dev-status.svg)](https://david-dm.org/aAXEe/online_chart_ol3/?type=dev)
 
-A new online chart based on [OpenLayers 3](http://openlayers.org/), [React](https://facebook.github.io/react/) and [Redux](http://redux.js.org/).
+A new online chart based on [OpenLayers 3](http://openlayers.org/), [React](https://facebook.github.io/react/), [Redux](http://redux.js.org/) and [Bootstrap](http://getbootstrap.com/).
 
-The build system is based on [Gulp Starter](https://github.com/vigetlabs/gulp-starter).
 
 # Online preview
 
@@ -11,199 +13,76 @@ Latest development state: http://aaxee.github.io/online_chart_ol3
 
 On our main server: http://alpha.openseamap.org
 
-# Basic Usage
-Make sure Node 4.4.3 (lts) is installed!
-We recommend using [NVM](https://github.com/creationix/nvm) or [n](https://github.com/tj/n) to manage node versions.
+# Development
 
-#### Install Dependencies
+Want to work on this project?
+Check this steps to get your development environment running!
+
+## Clone the repository
+
+Check the green button on the top to get a local copy of the repository.
+
+## Use with [Docker](https://www.docker.com/) and [Docker Compose](https://www.docker.com/products/docker-compose)
+
+No need to setup all stuff yourself! This repo provides a `Dockerfile`
+and a `docker-compose.yml` for a easy start:
+
+### Download and install Docker
+
+You need:
+- [Docker](https://www.docker.com/)
+(Version 1.10.0+)
+- [Docker Compose](https://www.docker.com/products/docker-compose)
+(Version 1.6.0+)
+
+### Prepare the development environment
+
 ```
-npm install
-bower install
+docker-compose build dev
 ```
 
-#### Start compiling, serving, and watching files
-```
-npm run gulp
-```
+This will build a docker image with `npm` and all dependencies. The build
+will take some time. Grab a cup of tea.  :tea:
 
-(or `npm run development`)
+### Run the development environment
 
-This runs `gulp` from `./node_modules/bin`, using the version installed with this project, rather than a globally installed instance. All commands in the package.json `scripts` work this way. The `gulp` command runs the `default` task, defined in `gulpfile.js/tasks/default.js`.
+To start up the development build:
+
+```
+docker-compose up dev
+```
 
 All files will compile in development mode (uncompressed with source maps). [BrowserSync](http://www.browsersync.io/) will serve up files to [localhost:3000](http://localhost:3000) and will stream live changes to the code and assets to all connected browsers. Don't forget about the additional BrowserSync tools available on [localhost:3001](http://localhost:3001)!
 
-To run any other existing task, simply add the task name after the `gulp` command. Example:
+Start to edit the files in `src/` and watch the browser reloading!
 
-```bash
-npm run gulp production
-```
+If you removed or added files you may need to stop the container [hint: <kbd>CTRL</kbd>+<kbd>C</kbd>]
+and restart it.
 
-#### Configuration
-Directory and top level settings are convienently exposed in `gulpfile.js/config.json`. All task configuration objects have `src` and `dest` directories specfied. These are relative to `root.src` and `root.dest` respectively. Each configuration also has an extensions array. This is used for file watching, and file deleting/replacing.
+If you add packages or change files in `gulpfile.js` don't forget to rebuild the
+container because all packages are installed and cached inside.
 
-If there is a feature you do not wish to use on your project, simply delete the configuration, and the task will be skipped.
+### More targets
 
-### Run JavaScript Tests
-```
-npm run test
-```
-Test files located in `__tests__` folders are picked up and run using
-[Karma](http://karma-runner.github.io/0.12/index.html), [Mocha](http://mochajs.org/), [Chai](http://chaijs.com/), and [Sinon](http://sinonjs.org/). The test script right now first compiles a production build, and then, if successful runs Karma. This is nice when using something like [Travis CI](https://travis-ci.org/vigetlabs/gulp-starter) in that if an error occurs during the build step, Travis alerts me that it failed. To pass, the files have to compile properly AND pass the JS tests.
-
-### Build production-ready files
-```
-npm run production
-```
-
-This will compile revisioned and compressed files to `./public`. To build production files and preview them localy, run
 
 ```
-npm run demo
+docker-compose up lint
 ```
 
-This will start a static server that serves your production files to http://localhost:5000. This is primarily meant as a way to preview your production build locally, not necessarily for use as a live production server.
+Runs the lint scripts and exits.
 
-### Deploy to gh-pages
 ```
-npm run deploy
-```
-This task compiles production code and then uses [gulp-gh-pages](https://github.com/shinnn/gulp-gh-pages) to push the contents of your `dest.root` to a `gh-pages` (or other specified) branch, viewable at http://[your-username].github.io/[your-repo-name]. Be sure to update the `homepage` property in your `package.json`.
-
-GitHub Pages isn't the most robust of hosting solutions (you'll eventually run into relative path issues), but it's a great place to quickly share in-progress work, and you get it for free.
-
-[Divshot](https://divshot.com/) and [Surge.sh](http://surge.sh/) are a couple great alternatives for production-ready static hosting to check out, and are just as easy to deploy to. Where ever you're deploying to, all you need to do is `npm run gulp production` and transfer the contents of the `public` folder to your server however you see fit.
-
-# Task Details
-
-#### JS
-```
-gulpfile.js/tasks/webpackWatch
-gulpfile.js/tasks/webpackProduction
-```
-Modular ES6 with [Babel](http://babeljs.io/) and [Webpack](http://webpack.github.io/)
-
-I've included various examples of generating mulitple files, async module loading and splitting out shared dependences to show the power of Webpack. Adjust the webpack config (`.gulpfile.js/config/webpack`) to fit your project. For smaller one-pagers, you'll probably want to skip the async stuff, and just compile a single bundle.
-
-There are a couple of webpack options exposed in the top-level `gulpfile.js/config.json` file.
-
-`entries`: Discrete js bundle entry points. A js file will be bundled for each item. Paths are relative to the `javascripts` folder. This maps directly to `webpackConfig.entry`.
-
-`extractSharedJs`: Creates a `shared.js` file that contains any modules shared by multiple bundles. Useful on large sites with descrete js running on different pages that may share common modules or libraries. Not typically needed on smaller sites.
-
-If you want to mess with the specifics of the webpack config, check out `gulpfile.js/lib/webpack-multi-config.js`.
-
-#### CSS
-```
-gulpfile.js/tasks/css
-```
-Your Sass gets run through Autoprefixer, so don't prefix! The examples use the indented `.sass` syntax, but use whichever you prefer.
-
-#### HTML
-```
-gulpfile.js/tasks/html
-```
-Robust templating with [Nunjucks](https://mozilla.github.io/nunjucks/). Nunjucks is nearly identical in syntax to Twig (PHP), and replaces Swig (and Twig-like js templating language), which is no longer maintained.
-
-A global data file is set up at [src/html/data/global.json](src/html/data/global.json), is read in by the `html` task, and exposes the propertiesto your html templates. See [social-icons-font.html](src/html/shared/social-icons-font.html) for example usage.
-
-#### Fonts
-```
-gulpfile.js/tasks/fonts
-```
-All this task does is copy fonts from `./src/fonts` to `./public/fonts`. A sass `+font-face` mixin is included in `./src/stylesheets/base/mixins`.
-
-#### IconFont
-```
-gulpfile.js/tasks/iconFont
-```
-SVGs added to `src/icons` will be automatically compiled into an iconFont, and output to `./public/fonts`. At the same time, a `.sass` file will be output to `src/stylesheets/generated/_icons.sass`. This file contains mixins and classes based on the svg filename. If you want to edit the template that generates this file, it's at `gulpfile.js/tasks/iconFont/template.sass`
-
-##### Usage:
-With generated classes:
-```
-<span class="icon -twitter"></span>
+docker-compose up test
 ```
 
-With mixins:
-```sass
-.lil-birdy-guy
-  +icon--twitter
+Builds and runs all tests.
+
+```
+docker-compose up demo
 ```
 
-```scss
-.lil-birdy-guy {
-  @include icon--twitter;
-}
-```
+Builds the project in release mode and serves them to [localhost:5000](http://localhost:5000).
 
-```html
-<span class="lil-birdy-guy"></span>
-```
+## Use directly with `npm`
 
-*Don't forget about accessibility!*
-
-```html
-<span aria-label="Twitter" class="icon -twitter"></span>
-<!-- or -->
-<div class="icon -twitter"><span class="screen-reader">Twitter</span></div>
-```
-
-#### SVG Sprites
-```
-gulpfile.js/tasks/svgSprite
-```
-SVGs sprites are super powerful. This particular setup allows styling 2 different colors from your css. You can have unlimited colors hard coded into your svg.  
-
-In the following example, the first path will be `red`, the second will be `white`, and the third will be `blue`. Paths **without a fill attribute** will inherit the `fill` property from css. Paths with **fill="currentColor"** will inherit the current css `color` value, and hard-coded fills will not be overwritten, since inline styles trump css values.
-
-```sass
-.sprite
-  fill: red
-  color: white
-```
-
-```svg
-  <svg xmlns="http://www.w3.org/2000/svg">
-    <path d="..."/>
-    <path fill="currentColor" d="..."/>
-    <path fill="blue" d="..."/>
-  </svg>
-```
-
-I've included a helper to generate the required svg markup in `src/html/macros/helpers.html`, so you can just do:
-```html
-  {{ sprite('my-icon') }}
-```
-Which spits out:
-
-```html
-  <span class='sprite -my-icon'>
-    <svg viewBox="0 0 1 1"><use xlink:href='images/spritesheets/sprites.svg#my-icon' /></use></svg>
-  </span>
-```
-
-I recommend setting up your SVGs on a 500 x 500 canvas, centering your artwork, and expanding/combining any shapes of the same color. This last step is important.
-
-#### Static Files (favicons, app icons, etc.)
-There are some files that belong in your root destination directory that you won't want to process or revision in production. Things like [favicons, app icons, etc.](http://realfavicongenerator.net/), should go in `src/static`, and will get copied over to `public` as a last step (after revisioning in production). *Nothing* should ever go directly in `public`, since it gets completely trashed and re-built when running the `default` or `production` tasks.
-
-## Notable changes from 1.0
-- Full asset pipeline and static html compilation
-- `gulpfile.js` is now a directory
-- update directory structure
-- Replaced Browserify with [Webpack](http://webpack.github.io/docs/webpack-for-browserify-users.html)!
-  - Async CommonJS module requires
-  - Automatically splits out shared dependencies
-- New `html` task w/ Nunjucks templating/compiling
-- Replace CoffeeScript with ES6 ([Babel.js](http://babeljs.io/))
-- New `server` task to test production files locally
-- New `deploy` task to deploy the public directory to gh-pages
-- New `rev` task that revisions filenames and compress css and js
-- Use `gulp-watch` instead of `gulp.watch` (correctly handles new files)
-- New `production` task runs tests, compression + filename revisioning
-- Remove old examples and extraneous dependencies
-- Upgrades dependencies
-- Added example Travis CI integration that runs karma tests and production build
-- Add SVG sprite implementation from @synapticism in #100
-
-**Check out other open source work happening at [Viget](http://viget.com) on [code.viget.com](http://code.viget.com)**
+You can use for own install of npm. See [gulpfile.js/README.md](./gulpfile.js/README.md) for details.

--- a/docker-common-node.yml
+++ b/docker-common-node.yml
@@ -1,0 +1,9 @@
+version: '2'
+
+services:
+  base:
+    build: .
+    volumes:
+     - ./src:/code/src
+    environment:
+      - NPM_CONFIG_LOGLEVEL=warn

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,31 @@
+version: '2'
+
+services:
+  dev:
+    extends:
+      file: docker-common-node.yml
+      service: base
+    ports:
+     - "3000:3000"
+     - "3001:3001"
+    command: npm run gulp
+
+  test:
+    extends:
+      file: docker-common-node.yml
+      service: base
+    command: npm run test
+
+  lint:
+    extends:
+      file: docker-common-node.yml
+      service: base
+    command: npm run gulp lint
+
+  demo:
+    extends:
+      file: docker-common-node.yml
+      service: base
+    ports:
+     - "5000:5000"
+    command: npm run demo

--- a/gulpfile.js/README.md
+++ b/gulpfile.js/README.md
@@ -1,0 +1,185 @@
+# Build system
+
+This directory contains the build system for the website.
+This readme describes details for the build.
+
+The build system is based on [Gulp Starter](https://github.com/vigetlabs/gulp-starter).
+
+
+# Usage with local npm
+Make sure Node 4.4.3 (lts) is installed!
+We recommend using [NVM](https://github.com/creationix/nvm) or [n](https://github.com/tj/n) to manage node versions.
+
+All commands should be run in the top level folder.
+
+#### Install Dependencies
+```
+npm install
+bower install
+```
+
+#### Start compiling, serving, and watching files
+```
+npm run gulp
+```
+
+(or `npm run development`)
+
+This runs `gulp` from `./node_modules/bin`, using the version installed with this project, rather than a globally installed instance. All commands in the package.json `scripts` work this way. The `gulp` command runs the `default` task, defined in `gulpfile.js/tasks/default.js`.
+
+All files will compile in development mode (uncompressed with source maps). [BrowserSync](http://www.browsersync.io/) will serve up files to [localhost:3000](http://localhost:3000) and will stream live changes to the code and assets to all connected browsers. Don't forget about the additional BrowserSync tools available on [localhost:3001](http://localhost:3001)!
+
+To run any other existing task, simply add the task name after the `gulp` command. Example:
+
+```bash
+npm run gulp production
+```
+
+#### Configuration
+Directory and top level settings are convienently exposed in `gulpfile.js/config.json`. All task configuration objects have `src` and `dest` directories specfied. These are relative to `root.src` and `root.dest` respectively. Each configuration also has an extensions array. This is used for file watching, and file deleting/replacing.
+
+If there is a feature you do not wish to use on your project, simply delete the configuration, and the task will be skipped.
+
+### Run JavaScript Tests
+```
+npm run test
+```
+Test files located in `__tests__` folders are picked up and run using
+[Karma](http://karma-runner.github.io/0.12/index.html), [Mocha](http://mochajs.org/), [Chai](http://chaijs.com/), and [Sinon](http://sinonjs.org/). The test script right now first compiles a production build, and then, if successful runs Karma. This is nice when using something like [Travis CI](https://travis-ci.org/vigetlabs/gulp-starter) in that if an error occurs during the build step, Travis alerts me that it failed. To pass, the files have to compile properly AND pass the JS tests.
+
+### Build production-ready files
+```
+npm run production
+```
+
+This will compile revisioned and compressed files to `./public`. To build production files and preview them localy, run
+
+```
+npm run demo
+```
+
+This will start a static server that serves your production files to http://localhost:5000. This is primarily meant as a way to preview your production build locally, not necessarily for use as a live production server.
+
+### Deploy to gh-pages
+```
+npm run deploy
+```
+This task compiles production code and then uses [gulp-gh-pages](https://github.com/shinnn/gulp-gh-pages) to push the contents of your `dest.root` to a `gh-pages` (or other specified) branch, viewable at http://[your-username].github.io/[your-repo-name]. Be sure to update the `homepage` property in your `package.json`.
+
+GitHub Pages isn't the most robust of hosting solutions (you'll eventually run into relative path issues), but it's a great place to quickly share in-progress work, and you get it for free.
+
+[Divshot](https://divshot.com/) and [Surge.sh](http://surge.sh/) are a couple great alternatives for production-ready static hosting to check out, and are just as easy to deploy to. Where ever you're deploying to, all you need to do is `npm run gulp production` and transfer the contents of the `public` folder to your server however you see fit.
+
+# Task Details
+
+#### JS
+```
+gulpfile.js/tasks/webpackWatch
+gulpfile.js/tasks/webpackProduction
+```
+Modular ES6 with [Babel](http://babeljs.io/) and [Webpack](http://webpack.github.io/)
+
+I've included various examples of generating mulitple files, async module loading and splitting out shared dependences to show the power of Webpack. Adjust the webpack config (`.gulpfile.js/config/webpack`) to fit your project. For smaller one-pagers, you'll probably want to skip the async stuff, and just compile a single bundle.
+
+There are a couple of webpack options exposed in the top-level `gulpfile.js/config.json` file.
+
+`entries`: Discrete js bundle entry points. A js file will be bundled for each item. Paths are relative to the `javascripts` folder. This maps directly to `webpackConfig.entry`.
+
+`extractSharedJs`: Creates a `shared.js` file that contains any modules shared by multiple bundles. Useful on large sites with descrete js running on different pages that may share common modules or libraries. Not typically needed on smaller sites.
+
+If you want to mess with the specifics of the webpack config, check out `gulpfile.js/lib/webpack-multi-config.js`.
+
+#### CSS
+```
+gulpfile.js/tasks/css
+```
+Your Sass gets run through Autoprefixer, so don't prefix! The examples use the indented `.sass` syntax, but use whichever you prefer.
+
+#### HTML
+```
+gulpfile.js/tasks/html
+```
+Robust templating with [Nunjucks](https://mozilla.github.io/nunjucks/). Nunjucks is nearly identical in syntax to Twig (PHP), and replaces Swig (and Twig-like js templating language), which is no longer maintained.
+
+A global data file is set up at [src/html/data/global.json](src/html/data/global.json), is read in by the `html` task, and exposes the propertiesto your html templates. See [social-icons-font.html](src/html/shared/social-icons-font.html) for example usage.
+
+#### Fonts
+```
+gulpfile.js/tasks/fonts
+```
+All this task does is copy fonts from `./src/fonts` to `./public/fonts`. A sass `+font-face` mixin is included in `./src/stylesheets/base/mixins`.
+
+#### IconFont
+```
+gulpfile.js/tasks/iconFont
+```
+SVGs added to `src/icons` will be automatically compiled into an iconFont, and output to `./public/fonts`. At the same time, a `.sass` file will be output to `src/stylesheets/generated/_icons.sass`. This file contains mixins and classes based on the svg filename. If you want to edit the template that generates this file, it's at `gulpfile.js/tasks/iconFont/template.sass`
+
+##### Usage:
+With generated classes:
+```
+<span class="icon -twitter"></span>
+```
+
+With mixins:
+```sass
+.lil-birdy-guy
+  +icon--twitter
+```
+
+```scss
+.lil-birdy-guy {
+  @include icon--twitter;
+}
+```
+
+```html
+<span class="lil-birdy-guy"></span>
+```
+
+*Don't forget about accessibility!*
+
+```html
+<span aria-label="Twitter" class="icon -twitter"></span>
+<!-- or -->
+<div class="icon -twitter"><span class="screen-reader">Twitter</span></div>
+```
+
+#### SVG Sprites
+```
+gulpfile.js/tasks/svgSprite
+```
+SVGs sprites are super powerful. This particular setup allows styling 2 different colors from your css. You can have unlimited colors hard coded into your svg.  
+
+In the following example, the first path will be `red`, the second will be `white`, and the third will be `blue`. Paths **without a fill attribute** will inherit the `fill` property from css. Paths with **fill="currentColor"** will inherit the current css `color` value, and hard-coded fills will not be overwritten, since inline styles trump css values.
+
+```sass
+.sprite
+  fill: red
+  color: white
+```
+
+```svg
+  <svg xmlns="http://www.w3.org/2000/svg">
+    <path d="..."/>
+    <path fill="currentColor" d="..."/>
+    <path fill="blue" d="..."/>
+  </svg>
+```
+
+I've included a helper to generate the required svg markup in `src/html/macros/helpers.html`, so you can just do:
+```html
+  {{ sprite('my-icon') }}
+```
+Which spits out:
+
+```html
+  <span class='sprite -my-icon'>
+    <svg viewBox="0 0 1 1"><use xlink:href='images/spritesheets/sprites.svg#my-icon' /></use></svg>
+  </span>
+```
+
+I recommend setting up your SVGs on a 500 x 500 canvas, centering your artwork, and expanding/combining any shapes of the same color. This last step is important.
+
+#### Static Files (favicons, app icons, etc.)
+There are some files that belong in your root destination directory that you won't want to process or revision in production. Things like [favicons, app icons, etc.](http://realfavicongenerator.net/), should go in `src/static`, and will get copied over to `public` as a last step (after revisioning in production). *Nothing* should ever go directly in `public`, since it gets completely trashed and re-built when running the `default` or `production` tasks.

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -12,7 +12,7 @@ var karmaConfig = {
   webpack: webpackConfig('test'),
   singleRun: process.env.TRAVIS === 'true',
 //  reporters: ['nyan'],
-  browsers: [(process.env.TRAVIS === 'true'? 'Firefox' : 'Chrome')]
+  browsers: ['PhantomJS']
 }
 
 karmaConfig.preprocessors[testSrc] = ['webpack']

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "karma-firefox-launcher": "^1.0.0",
     "karma-mocha": "^1.1.1",
     "karma-nyan-reporter": "0.2.4",
+    "karma-phantomjs-launcher": "^1.0.1",
     "karma-sinon-chai": "^1.2.0",
     "karma-webpack": "1.8.0",
     "lodash": "^4.2.1",


### PR DESCRIPTION
How to make sure that all developers use the same (or at least working) version of `npm`and all tools?
Provide them in inside a container.

The `dockerfile` is a simple recipe to build our build system with gulp and all other dependencies. Docker-compose simplifies the creation and startup of the containers.